### PR TITLE
Assume CrRenderer thread to be the one with the most events

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,15 +21,22 @@ export default class Tracelib {
     }
 
     private _findMainTrack(): Track {
-        const mainTrack = this._performanceModel
+        const threads: Track[] = this._performanceModel
             .timelineModel()
             .tracks()
-            .find((track: Track): boolean => Boolean(
-                track.type === TrackType.MainThread && track.forMainFrame && track.events.length
-            ))
 
+        const mainTrack = threads.find((track: Track): boolean => Boolean(
+            track.type === TrackType.MainThread && track.forMainFrame && track.events.length
+        ))
+
+        /**
+         * If no main thread could be found, pick the thread with most events
+         * captured in it and assume this is the main track.
+         */
         if (!mainTrack) {
-            throw new Error('MainTrack is missing in traceLog')
+            return threads.slice(1).reduce(
+                (curr: Track, com: Track): Track => curr.events.length > com.events.length ? curr : com,
+                threads[0])
         }
 
         return mainTrack

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -52,7 +52,11 @@ describe('mainTrackEvents', () => {
     })
 
     it('should throws error if main track is missing', () => {
+        /**
+         * use tracelog with CrRenderer thread name metadata missing
+         */
         const borkedTrace = JANK_TRACE_LOG.slice(0, -1)
+
         const tracelib = new Tracelib(borkedTrace)
         const result = tracelib.getMainTrackEvents()
         expect(result.length).toEqual(56244)

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -27,12 +27,6 @@ describe('getSummary', () => {
         expect(result).toMatchSnapshot()
     })
 
-    it('should throw error if main track is missing', () => {
-        const tracelib = new Tracelib([])
-        expect(() => tracelib.getSummary())
-            .toThrow(new Error('MainTrack is missing in traceLog'))
-    })
-
     it('should get summary data between passed range', () => {
         const result = trace.getSummary(289960055.634, 289960729.717)
         expect(result).toMatchSnapshot()
@@ -43,12 +37,6 @@ describe('getWarningCounts', () => {
     it('should get warning counts', () => {
         const result = trace.getWarningCounts()
         expect(result).toMatchSnapshot()
-    })
-
-    it('should throw error if main track is missing', () => {
-        const tracelib = new Tracelib([])
-        expect(() => tracelib.getWarningCounts())
-            .toThrow(new Error('MainTrack is missing in traceLog'))
     })
 })
 
@@ -64,8 +52,9 @@ describe('mainTrackEvents', () => {
     })
 
     it('should throws error if main track is missing', () => {
-        const tracelib = new Tracelib([])
-        expect(() => tracelib.getMainTrackEvents())
-            .toThrow(new Error('MainTrack is missing in traceLog'))
+        const borkedTrace = JANK_TRACE_LOG.slice(0, -1)
+        const tracelib = new Tracelib(borkedTrace)
+        const result = tracelib.getMainTrackEvents()
+        expect(result.length).toEqual(56244)
     })
 })


### PR DESCRIPTION
## Problem

While testing this library we found that Chrome sometimes misses to capture all meta correctly. In ~10% of trace logs captured from Alexas 500 top used pages there following trace event is missing:

```js
{"pid":99225,"tid":775,"ts":0,"ph":"M","cat":"__metadata","name":"thread_name","args":{"name":"CrRendererMain"}}
```

Which causes an error when trying to calculate a bunch of metrics.

## Solution

As a workaround let's assume that the main thread is the one with the most events connected to it.