### PR TITLE
Use complete trace window for metric calculation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -54,8 +54,8 @@ export default class Tracelib {
 
     public getSummary(from?: number, to?: number): StatsObject {
         const timelineUtils = new TimelineUIUtils()
-        const startTime = from || this._performanceModel.startTime
-        const endTime = to || this._performanceModel.endTime
+        const startTime = from || this._performanceModel.timelineModel().minimumRecordTime()
+        const endTime = to || this._performanceModel.timelineModel().maximumRecordTime()
         const mainTrack = this._findMainTrack()
 
         // We are facing data mutaion issue in devtools, to avoid it cloning syncEvents


### PR DESCRIPTION
## Problem

By default the inspection window was set to the low utilization region which sometimes was either the whole trace duration or just the first view seconds. Given that you are usually interested for these metrics on the whole spectrum it should be better to always look into the whole tracelog.

## Summary

Use minimum/maximum record time as default to calculate metrics from.